### PR TITLE
Support self_unread option

### DIFF
--- a/client.js
+++ b/client.js
@@ -23,7 +23,7 @@
         'body': params.body
       };
       if (params.self_unread !== undefined) {
-        post_data['self_unread'] = params.self_unread;
+        post_data.self_unread = params.self_unread;
       }
       return this.post('/rooms/'+ params.room_id +'/messages', post_data);
     };

--- a/client.js
+++ b/client.js
@@ -21,8 +21,10 @@
     ChatWork.prototype.sendMessage = function(params) { 
       var post_data = {
         'body': params.body
+      };
+      if (params.self_unread !== undefined) {
+        post_data['self_unread'] = params.self_unread;
       }
-      
       return this.post('/rooms/'+ params.room_id +'/messages', post_data);
     };
     


### PR DESCRIPTION
## Background

refs. https://developer.chatwork.com/ja/endpoint_rooms.html#POST-rooms-room_id-messages

`POST /v2/rooms/{room_id}/messages` には`self_unread`というオプションがあるが、`ChatWork.sendMessage`は現在それに対応していません。
`ChatWork.post`を直接呼ぶことで回避は出来るのですが、不便なため、`self_unread`オプションを扱えるようにしたいです。


## Proposal

`sendMessage`メソッドが`self_unread`を扱えるようにします。


レビューをお願い致します。